### PR TITLE
Fix meta error for license.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ keywords = [
     "project template",
     "template",
 ]
-license = {file = "LICENSE"}
 name = "serious_scaffold"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--3.org.readthedocs.build/en/3/

<!-- readthedocs-preview serious-scaffold-python end -->