### PR TITLE
No redundant newline at the end of coper answers file.

### DIFF
--- a/{{_copier_conf.answers_file}}.jinja
+++ b/{{_copier_conf.answers_file}}.jinja
@@ -1,1 +1,1 @@
-{{_copier_answers|to_nice_yaml}}
+{{ _copier_answers|to_nice_yaml -}}


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--19.org.readthedocs.build/en/19/

<!-- readthedocs-preview serious-scaffold-python end -->