### PR TITLE
Fix typo for make clean in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 	find . -name '*.egg-info' -print0 | xargs -0 rm -rf
 	find . -name '*.pyc' -print0 | xargs -0 rm -f
 	find . -name '*.swp' -print0 | xargs -0 rm -f
-	find . -name '.DS_Store' -print0 | xargs -0 rm -r
+	find . -name '.DS_Store' -print0 | xargs -0 rm -f
 	find . -name '__pycache__' -print0 | xargs -0 rm -rf
 
 deepclean: clean


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--23.org.readthedocs.build/en/23/

<!-- readthedocs-preview serious-scaffold-python end -->