### PR TITLE
Check minimal test coverage in make tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ toml-sort:
 	${PIPRUN} toml-sort pyproject.toml
 
 tests:
-	${PIPRUN} python -m pytest .
+	${PIPRUN} python -m pytest --cov-fail-under=$(or $(SS_TEST_COVERAGE_MIN),100) .
 
 freeze:
 	@${PIPRUN} pip freeze --exclude-editable

--- a/Makefile.jinja
+++ b/Makefile.jinja
@@ -62,7 +62,7 @@ toml-sort:
 	${PIPRUN} toml-sort pyproject.toml
 
 tests:
-	${PIPRUN} python -m pytest .
+	${PIPRUN} python -m pytest --cov-fail-under=$(or $(SS_TEST_COVERAGE_MIN),100) .
 
 freeze:
 	@${PIPRUN} pip freeze --exclude-editable


### PR DESCRIPTION
Fix #29 

<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--35.org.readthedocs.build/en/35/

<!-- readthedocs-preview serious-scaffold-python end -->